### PR TITLE
Encode all non-alphanumeric characters in technology names and logos

### DIFF
--- a/src/readme.rs
+++ b/src/readme.rs
@@ -1,7 +1,7 @@
 use crate::conf;
 
 use anyhow::bail;
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 pub fn gen_table(
     env_conf: &conf::Env,
@@ -17,7 +17,7 @@ pub fn gen_table(
     ));
     lines.push(String::from("| - | - |"));
 
-    const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
+    const FRAGMENT: &AsciiSet = &NON_ALPHANUMERIC;
 
     for tech in file_conf.iter() {
         let mut projects = Vec::new();


### PR DESCRIPTION
## Description

This fixes badges like this: ![](https://img.shields.io/static/v1?label=&message=C#&color=512BD4&logo=dotnet&logoColor=FFFFFF)
```
https://img.shields.io/static/v1?label=&message=C#&color=512BD4&logo=dotnet&logoColor=FFFFFF
```
by replacing the `#` in the `&message` query to `%23`

and now it looks like this: ![](https://img.shields.io/static/v1?label=&message=C%23&color=512BD4&logo=dotnet&logoColor=FFFFFF)

Encoding all non-alphanumeric characters should be safe for just tech name and logo. From trial and error, I found out that only a small set of symbols (not included in the [fragment encoding](https://url.spec.whatwg.org/#fragment-percent-encode-set)) cause this issue (including `+`, `#`, `&`, `%`).

## Steps

- [ ] My change requires a change to the documentation
- [ ] I have updated the accessible documentation according
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

No issue has been opened yet.
